### PR TITLE
`writeText` returns a promise

### DIFF
--- a/src/CommitMessage.svelte
+++ b/src/CommitMessage.svelte
@@ -3,8 +3,9 @@
   $: commitMessage = coAuthors.join("<br>");
 
   function copyToClipboard() {
-    navigator.clipboard.writeText(coAuthors.join("\n"));
-    alert("Snippet copied to clipboard")
+    navigator.clipboard.writeText(coAuthors.join("\n")).then(() => {
+        alert("Snippet copied to clipboard")
+      })
   }
 </script>
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/69438702/why-does-navigator-clipboard-writetext-not-copy-text-to-clipboard-if-it-is-pro

Currently in Chrome this throws a `DOMException`, probably because there is an `alert` showing when the copying executes.